### PR TITLE
Removed use of CFURLPathStyle in public headers as this might cause ABI ...

### DIFF
--- a/CF++/include/CF++/CFPP-URL.h
+++ b/CF++/include/CF++/CFPP-URL.h
@@ -66,6 +66,13 @@ namespace CF
             }
             Part;
             
+            typedef enum
+            {
+                PathStylePOSIX      = 0x00,
+                PathStyleWindows    = 0x01
+            }
+            PathStyle;
+            
             static URL FileSystemURL( std::string path, bool isDir = false );
             static URL FileSystemURL( CFTypeRef path, bool isDir = false );
             static URL FileSystemURL( CFStringRef path, bool isDir = false );
@@ -107,7 +114,7 @@ namespace CF
             virtual CFTypeID  GetTypeID( void ) const;
             virtual CFTypeRef GetCFObject( void ) const;
             
-            CF::String GetFileSystemPath( CFURLPathStyle style = kCFURLPOSIXPathStyle );
+            CF::String GetFileSystemPath( PathStyle style = PathStylePOSIX );
             CF::String GetFragment( void );
             CF::String GetHostName( void );
             CF::String GetLastPathComponent( void );

--- a/CF++/source/CFPP-URL.cpp
+++ b/CF++/source/CFPP-URL.cpp
@@ -371,17 +371,19 @@ namespace CF
         return this->_cfObject;
     }
     
-    CF::String URL::GetFileSystemPath( CFURLPathStyle style )
+    CF::String URL::GetFileSystemPath( PathStyle style )
     {
-        CF::String  str;
-        CFStringRef cfStr;
+        CF::String      str;
+        CFStringRef     cfStr;
+        CFURLPathStyle  cfPathStyle;
         
         if( this->_cfObject == NULL )
         {
             return str;
         }
         
-        cfStr = CFURLCopyFileSystemPath( this->_cfObject, style );
+        cfPathStyle = ( style == PathStyleWindows ) ? kCFURLWindowsPathStyle : kCFURLPOSIXPathStyle;
+        cfStr       = CFURLCopyFileSystemPath( this->_cfObject, cfPathStyle );
         
         if( cfStr != NULL )
         {


### PR DESCRIPTION
...issues when mixing C++ STD versions due to scoped enums.
