### PR TITLE
Feature: bridging release

### DIFF
--- a/CF++/include/CF++.hpp
+++ b/CF++/include/CF++.hpp
@@ -56,6 +56,31 @@
 #endif
 
 #include <CF++/CFPP-Type.hpp>
+
+namespace CF
+{
+	/*!
+		@brief CFPP class for CF type.
+		Support binding CFPP types with their matching CF types for overloaded CF::BridgingRelease function
+	 */
+	template<typename>struct ClassFor; template<> struct ClassFor<CFTypeRef> { typedef CF::Type type; };
+
+	/*!
+		@function BridgingRelease
+		@brief Convert a CF object into it's matching CFPP type.
+		@note This function is implicitly defined for all CF types that CFPP wraps.
+		@param cf A valid CoreFoundation object or NULL. A non-NULL value will be released.
+		@return A CFPP object constructed with the CoreFoundation object. If the object is NULL, the default constructor is used.
+	 */
+	template <typename CFType>
+	static inline typename ClassFor<CFType>::type BridgingRelease(CFType CF_RELEASES_ARGUMENT cf) {
+		if (cf == nullptr) return typename ClassFor<CFType>::type();
+		typename ClassFor<CFType>::type cfpp(cf);
+		CFRelease(cf);
+		return cfpp;
+	}
+}
+
 #include <CF++/CFPP-PropertyListType.hpp>
 #include <CF++/CFPP-AutoPointer.hpp>
 #include <CF++/CFPP-Boolean.hpp>

--- a/CF++/include/CF++/CFPP-Array.hpp
+++ b/CF++/include/CF++/CFPP-Array.hpp
@@ -142,6 +142,10 @@ namespace CF
             
             CFMutableArrayRef _cfObject;
     };
+
+	template<typename>struct ClassFor; template<> struct ClassFor<CFArrayRef> { typedef CF::Array type; };
+
+	template<typename>struct ClassFor; template<> struct ClassFor<CFMutableArrayRef> { typedef CF::Array type; };
 }
 
 #endif /* CFPP_ARRAY_H */

--- a/CF++/include/CF++/CFPP-Boolean.hpp
+++ b/CF++/include/CF++/CFPP-Boolean.hpp
@@ -84,6 +84,8 @@ namespace CF
             
             CFBooleanRef _cfObject;
     };
+
+	template<typename>struct ClassFor; template<> struct ClassFor<CFBooleanRef> { typedef CF::Boolean type; };
 }
 
 #endif /* CFPP_BOOLEAN_H */

--- a/CF++/include/CF++/CFPP-Data.hpp
+++ b/CF++/include/CF++/CFPP-Data.hpp
@@ -150,6 +150,10 @@ namespace CF
             
             CFMutableDataRef _cfObject;
     };
+
+	template<typename>struct ClassFor; template<> struct ClassFor<CFDataRef> { typedef CF::Data type; };
+
+	template<typename>struct ClassFor; template<> struct ClassFor<CFMutableDataRef> { typedef CF::Data type; };
 }
 
 #endif /* CFPP_DATA_H */

--- a/CF++/include/CF++/CFPP-Date.hpp
+++ b/CF++/include/CF++/CFPP-Date.hpp
@@ -122,6 +122,8 @@ namespace CF
             
             CFDateRef _cfObject;
     };
+
+	template<typename>struct ClassFor; template<> struct ClassFor<CFDateRef> { typedef CF::Date type; };
 }
 
 #endif /* CFPP_DATE_H */

--- a/CF++/include/CF++/CFPP-Dictionary.hpp
+++ b/CF++/include/CF++/CFPP-Dictionary.hpp
@@ -140,6 +140,10 @@ namespace CF
             
             CFMutableDictionaryRef _cfObject;
     };
+
+	template<typename>struct ClassFor; template<> struct ClassFor<CFDictionaryRef> { typedef CF::Dictionary type; };
+
+	template<typename>struct ClassFor; template<> struct ClassFor<CFMutableDictionaryRef> { typedef CF::Dictionary type; };
 }
 
 #endif /* CFPP_DICTIONARY_H */

--- a/CF++/include/CF++/CFPP-Error.hpp
+++ b/CF++/include/CF++/CFPP-Error.hpp
@@ -81,6 +81,8 @@ namespace CF
             
             CFErrorRef _cfObject;
     };
+
+	template<typename>struct ClassFor; template<> struct ClassFor<CFErrorRef> { typedef CF::Error type; };
 }
 
 #endif /* CFPP_ERROR_H */

--- a/CF++/include/CF++/CFPP-Number.hpp
+++ b/CF++/include/CF++/CFPP-Number.hpp
@@ -524,6 +524,8 @@ namespace CF
             
             CFNumberRef _cfObject;
     };
+
+	template<typename>struct ClassFor; template<> struct ClassFor<CFNumberRef> { typedef CF::Number type; };
 }
 
 #endif /* CFPP_NUMBER_H */

--- a/CF++/include/CF++/CFPP-ReadStream.hpp
+++ b/CF++/include/CF++/CFPP-ReadStream.hpp
@@ -139,6 +139,8 @@ namespace CF
             
             CFReadStreamRef _cfObject;
     };
+
+	template<typename>struct ClassFor; template<> struct ClassFor<CFReadStreamRef> { typedef CF::ReadStream type; };
 }
 
 #endif /* CFPP_READ_STREAM_H */

--- a/CF++/include/CF++/CFPP-String.hpp
+++ b/CF++/include/CF++/CFPP-String.hpp
@@ -164,6 +164,10 @@ namespace CF
             
             CFStringRef _cfObject;
     };
+
+	template<typename>struct ClassFor; template<> struct ClassFor<CFStringRef> { typedef CF::String type; };
+
+	template<typename>struct ClassFor; template<> struct ClassFor<CFMutableStringRef> { typedef CF::String type; };
 }
 
 #endif /* CFPP_STRING_H */

--- a/CF++/include/CF++/CFPP-URL.hpp
+++ b/CF++/include/CF++/CFPP-URL.hpp
@@ -146,6 +146,8 @@ namespace CF
             
             CFURLRef _cfObject;
     };
+
+	template<typename>struct ClassFor; template<> struct ClassFor<CFURLRef> { typedef CF::URL type; };
 }
 
 #endif /* CFPP_URL_H */

--- a/CF++/include/CF++/CFPP-UUID.hpp
+++ b/CF++/include/CF++/CFPP-UUID.hpp
@@ -80,6 +80,8 @@ namespace CF
             
             CFUUIDRef _cfObject;
     };
+
+	template<typename>struct ClassFor; template<> struct ClassFor<CFUUIDRef> { typedef CF::UUID type; };
 }
 
 #endif /* CFPP_UUID_H */

--- a/CF++/include/CF++/CFPP-WriteStream.hpp
+++ b/CF++/include/CF++/CFPP-WriteStream.hpp
@@ -80,6 +80,8 @@ namespace CF
             
             CFWriteStreamRef _cfObject;
     };
+
+	template<typename>struct ClassFor; template<> struct ClassFor<CFWriteStreamRef> { typedef CF::WriteStream type; };
 }
 
 #endif /* CFPP_WRITE_STREAM_H */

--- a/Unit-Tests/Test-CFPP-Array.cpp
+++ b/Unit-Tests/Test-CFPP-Array.cpp
@@ -192,3 +192,44 @@ TEST( CFPP_Array, Swap )
     ASSERT_EQ( a1.GetCount(), 0 );
     ASSERT_EQ( a2.GetCount(), 2 );
 }
+
+// Hidden from analyzer because it misreports a leak
+#ifndef __clang_analyzer__
+TEST( CFPP_Array, BridgingRelease )
+{
+	// Wrapper copies, so retain count decreases after bridge
+
+	CFArrayRef cf = CFArrayCreate(NULL, NULL, 0, NULL);
+
+	CFRetain(cf);
+
+	CFIndex retainCount = CFGetRetainCount(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CF::Array cpp = CF::BridgingRelease(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount - 1);
+
+	CFRelease(cf);
+}
+
+TEST( CFPP_Array, BridgingReleaseM )
+{
+	// Wrapper copies, so retain count decreases after bridge
+
+	CFMutableArrayRef cf = CFArrayCreateMutable(NULL, 0, NULL);
+	
+	CFRetain(cf);
+
+	CFIndex retainCount = CFGetRetainCount(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CF::Array cpp = CF::BridgingRelease(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount - 1);
+
+	CFRelease(cf);
+}
+#endif

--- a/Unit-Tests/Test-CFPP-Boolean.cpp
+++ b/Unit-Tests/Test-CFPP-Boolean.cpp
@@ -374,3 +374,20 @@ TEST( CFPP_Boolean, Swap )
     ASSERT_EQ( b1.GetValue(), false );
     ASSERT_EQ( b2.GetValue(), true );
 }
+
+TEST( CFPP_Boolean, BridgingRelease )
+{
+	// Wrapper retains, so retain count should be the same after bridge
+
+	CFBooleanRef cf = (CFBooleanRef)CFRetain(kCFBooleanTrue);
+
+	CFRetain(cf);
+
+	CFIndex retainCount = CFGetRetainCount(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CF::Boolean cpp = CF::BridgingRelease(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+}

--- a/Unit-Tests/Test-CFPP-Data.cpp
+++ b/Unit-Tests/Test-CFPP-Data.cpp
@@ -37,3 +37,44 @@
 #include <GoogleMock/GoogleMock.h>
 
 using namespace testing;
+
+// Hidden from analyzer because it misreports a leak
+#ifndef __clang_analyzer__
+TEST( CFPP_Data, BridgingRelease )
+{
+	// Wrapper copies, so retain count decreases after bridge
+
+	CFDataRef cf = CFDataCreate(NULL, NULL, 0);
+
+	CFRetain(cf);
+
+	CFIndex retainCount = CFGetRetainCount(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CF::Data cpp = CF::BridgingRelease(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount - 1);
+
+	CFRelease(cf);
+}
+
+TEST( CFPP_Data, BridgingReleaseM )
+{
+	// Wrapper copies, so retain count decreases after bridge
+
+	CFMutableDataRef cf = CFDataCreateMutable(NULL, 0);
+
+	CFRetain(cf);
+
+	CFIndex retainCount = CFGetRetainCount(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CF::Data cpp = CF::BridgingRelease(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount - 1);
+
+	CFRelease(cf);
+}
+#endif

--- a/Unit-Tests/Test-CFPP-Date.cpp
+++ b/Unit-Tests/Test-CFPP-Date.cpp
@@ -37,3 +37,25 @@
 #include <GoogleMock/GoogleMock.h>
 
 using namespace testing;
+
+// Hidden from analyzer because it misreports a leak
+#ifndef __clang_analyzer__
+TEST( CFPP_Date, BridgingRelease )
+{
+	// Wrapper retains, so retain count should be the same after bridge
+
+	CFDateRef cf = CFDateCreate(NULL, CFAbsoluteTimeGetCurrent());
+
+	CFRetain(cf);
+
+	CFIndex retainCount = CFGetRetainCount(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CF::Date cpp = CF::BridgingRelease(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CFRelease(cf);
+}
+#endif

--- a/Unit-Tests/Test-CFPP-Dictionary.cpp
+++ b/Unit-Tests/Test-CFPP-Dictionary.cpp
@@ -37,3 +37,44 @@
 #include <GoogleMock/GoogleMock.h>
 
 using namespace testing;
+
+// Hidden from analyzer because it misreports a leak
+#ifndef __clang_analyzer__
+TEST( CFPP_Dictionary, BridgingRelease )
+{
+	// Wrapper copies, so retain count decreases after bridge
+
+	CFDictionaryRef cf = CFDictionaryCreate(NULL, NULL, NULL, 0, NULL, NULL);
+
+	CFRetain(cf);
+
+	CFIndex retainCount = CFGetRetainCount(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CF::Dictionary cpp = CF::BridgingRelease(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount - 1);
+
+	CFRelease(cf);
+}
+
+TEST( CFPP_Dictionary, BridgingReleaseM )
+{
+	// Wrapper copies, so retain count decreases after bridge
+
+	CFMutableDictionaryRef cf = CFDictionaryCreateMutable(NULL, 0, NULL, NULL);
+
+	CFRetain(cf);
+
+	CFIndex retainCount = CFGetRetainCount(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CF::Dictionary cpp = CF::BridgingRelease(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount - 1);
+
+	CFRelease(cf);
+}
+#endif

--- a/Unit-Tests/Test-CFPP-Error.cpp
+++ b/Unit-Tests/Test-CFPP-Error.cpp
@@ -369,3 +369,25 @@ TEST( CFPP_Error, Swap )
     ASSERT_EQ( e2.GetDomain(), "com.xs-labs" );
     ASSERT_EQ( e2.GetCode(), 42 );
 }
+
+// Hidden from analyzer because it misreports a leak
+#ifndef __clang_analyzer__
+TEST( CFPP_Error, BridgingRelease )
+{
+	// Wrapper retains, so retain count should be the same after bridge
+
+	CFErrorRef cf = CFErrorCreate(NULL, CFSTR(""), 0, NULL);
+
+	CFRetain(cf);
+
+	CFIndex retainCount = CFGetRetainCount(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CF::Error cpp = CF::BridgingRelease(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CFRelease(cf);
+}
+#endif

--- a/Unit-Tests/Test-CFPP-Number.cpp
+++ b/Unit-Tests/Test-CFPP-Number.cpp
@@ -4418,3 +4418,26 @@ TEST( CFPP_Number, Swap )
     ASSERT_EQ( n1, 2 );
     ASSERT_EQ( n2, 1 );
 }
+
+// Hidden from analyzer because it misreports a leak
+#ifndef __clang_analyzer__
+TEST( CFPP_Number, BridgingRelease )
+{
+	// Wrapper retains, so retain count should be the same after bridge
+
+	int x = 42;
+	CFNumberRef cf = CFNumberCreate(NULL, kCFNumberIntType, &x);
+
+	CFRetain(cf);
+
+	CFIndex retainCount = CFGetRetainCount(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CF::Number cpp = CF::BridgingRelease(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CFRelease(cf);
+}
+#endif

--- a/Unit-Tests/Test-CFPP-ReadStream.cpp
+++ b/Unit-Tests/Test-CFPP-ReadStream.cpp
@@ -230,3 +230,25 @@ TEST( CFPP_ReadStream, SetClient )
 
 TEST( CFPP_ReadStream, Swap )
 {}
+
+// Hidden from analyzer because it misreports a leak
+#ifndef __clang_analyzer__
+TEST( CFPP_ReadStream, BridgingRelease )
+{
+	// Wrapper retains, so retain count should be the same after bridge
+
+	CFReadStreamRef cf = CFReadStreamCreateWithBytesNoCopy(NULL, NULL, 0, kCFAllocatorNull);
+
+	CFRetain(cf);
+
+	CFIndex retainCount = CFGetRetainCount(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CF::ReadStream cpp = CF::BridgingRelease(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CFRelease(cf);
+}
+#endif

--- a/Unit-Tests/Test-CFPP-String.cpp
+++ b/Unit-Tests/Test-CFPP-String.cpp
@@ -636,3 +636,44 @@ TEST( CFPP_String, Swap )
     ASSERT_EQ( s1.GetValue(), "hello, universe" );
     ASSERT_EQ( s2.GetValue(), "hello, world" );
 }
+
+// Hidden from analyzer because it misreports a leak
+#ifndef __clang_analyzer__
+TEST( CFPP_String, BridgingRelease )
+{
+	// Wrapper retains, so retain count should be the same after bridge
+
+	CFStringRef cf = CFStringCreateWithFormat(NULL, NULL, CFSTR(""));
+
+	CFRetain(cf);
+
+	CFIndex retainCount = CFGetRetainCount(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CF::String cpp = CF::BridgingRelease(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CFRelease(cf);
+}
+
+TEST( CFPP_String, BridgingReleaseM )
+{
+	// Wrapper retains, so retain count should be the same after bridge
+
+	CFMutableStringRef cf = CFStringCreateMutable(NULL, 0);
+
+	CFRetain(cf);
+
+	CFIndex retainCount = CFGetRetainCount(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CF::String cpp = CF::BridgingRelease(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CFRelease(cf);
+}
+#endif

--- a/Unit-Tests/Test-CFPP-URL.cpp
+++ b/Unit-Tests/Test-CFPP-URL.cpp
@@ -44,7 +44,7 @@ TEST( CFPP_URL, BridgingRelease )
 {
 	// Wrapper retains, so retain count should be the same after bridge
 
-	CFURLRef cf = CFURLCreateWithString(NULL, CFSTR(""), NULL);
+	CFURLRef cf = CFURLCreateWithString(NULL, CFSTR("/"), NULL);
 
 	CFRetain(cf);
 

--- a/Unit-Tests/Test-CFPP-URL.cpp
+++ b/Unit-Tests/Test-CFPP-URL.cpp
@@ -37,3 +37,25 @@
 #include <GoogleMock/GoogleMock.h>
 
 using namespace testing;
+
+// Hidden from analyzer because it misreports a leak
+#ifndef __clang_analyzer__
+TEST( CFPP_URL, BridgingRelease )
+{
+	// Wrapper retains, so retain count should be the same after bridge
+
+	CFURLRef cf = CFURLCreateWithString(NULL, CFSTR(""), NULL);
+
+	CFRetain(cf);
+
+	CFIndex retainCount = CFGetRetainCount(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CF::URL cpp = CF::BridgingRelease(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CFRelease(cf);
+}
+#endif

--- a/Unit-Tests/Test-CFPP-UUID.cpp
+++ b/Unit-Tests/Test-CFPP-UUID.cpp
@@ -320,3 +320,25 @@ TEST( CFPP_UUID, Swap )
     ASSERT_EQ( u1.GetString(), s2 );
     ASSERT_EQ( u2.GetString(), s1 );
 }
+
+// Hidden from analyzer because it misreports a leak
+#ifndef __clang_analyzer__
+TEST( CFPP_UUID, BridgingRelease )
+{
+	// Wrapper retains, so retain count should be the same after bridge
+
+	CFUUIDRef cf = CFUUIDCreate(NULL);
+
+	CFRetain(cf);
+
+	CFIndex retainCount = CFGetRetainCount(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CF::UUID cpp = CF::BridgingRelease(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CFRelease(cf);
+}
+#endif

--- a/Unit-Tests/Test-CFPP-WriteStream.cpp
+++ b/Unit-Tests/Test-CFPP-WriteStream.cpp
@@ -37,3 +37,25 @@
 #include <GoogleMock/GoogleMock.h>
 
 using namespace testing;
+
+// Hidden from analyzer because it misreports a leak
+#ifndef __clang_analyzer__
+TEST( CFPP_WriteStream, BridgingRelease )
+{
+	// Wrapper retains, so retain count should be the same after bridge
+
+	CFWriteStreamRef cf = CFWriteStreamCreateWithAllocatedBuffers(NULL, NULL);
+
+	CFRetain(cf);
+
+	CFIndex retainCount = CFGetRetainCount(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CF::WriteStream cpp = CF::BridgingRelease(cf);
+
+	ASSERT_EQ(CFGetRetainCount(cf), retainCount);
+
+	CFRelease(cf);
+}
+#endif


### PR DESCRIPTION
Adds function BridgingRelease that takes all supported CFTypes, implicitly returns instance of corresponding C++ type and consumes one reference. Modeled after CFBridgingRelease concept from ARC-enabled Objective-C. Includes unit tests.

Also adds meta-function ClassFor that allows you to define what C++ object to use for wrapping a given CFType.

resolves #17