### PR TITLE
Fix for implicit-conversion precision error

### DIFF
--- a/CF++/source/CFPP-Error.cpp
+++ b/CF++/source/CFPP-Error.cpp
@@ -280,7 +280,7 @@ namespace CF
             return n;
         }
         
-        n.SetSignedLongValue( static_cast< SInt64 >( CFErrorGetCode( this->_cfObject ) ) );
+        n.SetSignedLongLongValue( static_cast< SInt64 >( CFErrorGetCode( this->_cfObject ) ) );
         
         return n;
     }


### PR DESCRIPTION
When compiling on the command line with `xcodebuild -alltargets` I got this error:

        /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++ -arch armv7 -fmessage-length=168 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit=0 -fcolor-diagnostics -std=c++11 -stdlib=libc++ -fmodules -fmodules-prune-interval=86400 -fmodules-prune-after=345600 -fbuild-session-file=/var/folders/5h/k46wfdmx35s3dx5rb83490540000gp/C/org.llvm.clang/ModuleCache/Session.modulevalidation -fmodules-validate-once-per-build-session -Wnon-modular-include-in-framework-module -Werror=non-modular-include-in-framework-module -Wno-trigraphs -fpascal-strings -Os -Werror -Werror=incompatible-pointer-types -Wmissing-field-initializers -Wmissing-prototypes -Werror=return-type -Wdocumentation -Wunreachable-code -Werror=deprecated-objc-isa-usage -Werror=objc-root-class -Wnon-virtual-dtor -Woverloaded-virtual -Wexit-time-destructors -Wmissing-braces -Wparentheses -Wswitch -Wunused-function -Wunused-label -Wunused-parameter -Wunused-variable -Wunused-value -Wempty-body -Wconditional-uninitialized -Wunknown-pragmas -pedantic -Wshadow -Wfour-char-constants -Wconversion -Wconstant-conversion -Wint-conversion -Wbool-conversion -Wenum-conversion -Wassign-enum -Wsign-compare -Wshorten-64-to-32 -Wnewline-eof -Wc++11-extensions -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.4.sdk -fstrict-aliasing -Wdeprecated-declarations -Winvalid-offsetof -g -Wsign-conversion -miphoneos-version-min=6.0 -iquote /tmp/CFPP/build/CoreFoundation++.build/Release-iphoneos/CF++\ iOS\ Static\ Library\ (C++11).build/CF++-generated-files.hmap -I/tmp/CFPP/build/CoreFoundation++.build/Release-iphoneos/CF++\ iOS\ Static\ Library\ (C++11).build/CF++-own-target-headers.hmap -I/tmp/CFPP/build/CoreFoundation++.build/Release-iphoneos/CF++\ iOS\ Static\ Library\ (C++11).build/CF++-all-non-framework-target-headers.hmap -ivfsoverlay /tmp/CFPP/build/CoreFoundation++.build/all-product-headers.yaml -iquote /tmp/CFPP/build/CoreFoundation++.build/Release-iphoneos/CF++\ iOS\ Static\ Library\ (C++11).build/CF++-project-headers.hmap -I/tmp/CFPP/build/Release-iphoneos/include -I/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include -ICF++/include -I/tmp/CFPP/build/CoreFoundation++.build/Release-iphoneos/CF++\ iOS\ Static\ Library\ (C++11).build/DerivedSources/armv7 -I/tmp/CFPP/build/CoreFoundation++.build/Release-iphoneos/CF++\ iOS\ Static\ Library\ (C++11).build/DerivedSources -F/tmp/CFPP/build/Release-iphoneos -include /var/folders/5h/k46wfdmx35s3dx5rb83490540000gp/C/com.apple.DeveloperTools/6.4-6E35b/Xcode/SharedPrecompiledHeaders/PrefixHeader-awdueqeocfsnlxbrzkkohhooffut/PrefixHeader.pch -MMD -MT dependencies -MF /tmp/CFPP/build/CoreFoundation++.build/Release-iphoneos/CF++\ iOS\ Static\ Library\ (C++11).build/Objects-normal/armv7/CFPP-Error.d --serialize-diagnostics /tmp/CFPP/build/CoreFoundation++.build/Release-iphoneos/CF++\ iOS\ Static\ Library\ (C++11).build/Objects-normal/armv7/CFPP-Error.dia -c /tmp/CFPP/CF++/source/CFPP-Error.cpp -o /tmp/CFPP/build/CoreFoundation++.build/Release-iphoneos/CF++\ iOS\ Static\ Library\ (C++11).build/Objects-normal/armv7/CFPP-Error.o
    /tmp/CFPP/CF++/source/CFPP-Error.cpp:283:31: fatal error: implicit conversion loses integer precision: 'SInt64' (aka 'long long') to 'long' [-Wshorten-64-to-32]
            n.SetSignedLongValue( static_cast< SInt64 >( CFErrorGetCode( this->_cfObject ) ) );
            ~                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    1 error generated.

… Changing the setter call to `CF::Number::SetSignedLongLongValue` (note extra “Long” in there) made everything compile and test OK on my end. 

Here’s the error in context: 
![the error in context](http://i.imgur.com/OamkE0V.jpg)

… the full, unbelievably verbose output from `xcodebuild -alltargets` is here: https://gist.github.com/fish2000/32ae6073e7b2b4e79a2e