### PR TITLE
Added functions GetKeyTypeID, GetValueTypeID to Pair

### DIFF
--- a/CF++/include/CF++/CFPP-Pair.hpp
+++ b/CF++/include/CF++/CFPP-Pair.hpp
@@ -63,6 +63,8 @@ namespace CF
             
             CFTypeRef GetKey( void ) const;
             CFTypeRef GetValue( void ) const;
+			CFTypeID GetKeyTypeID(void) const;
+			CFTypeID GetValueTypeID(void) const;
             void      SetKey( CFTypeRef key );
             void      SetValue( CFTypeRef value );
             

--- a/CF++/source/CFPP-Pair.cpp
+++ b/CF++/source/CFPP-Pair.cpp
@@ -159,6 +159,18 @@ namespace CF
     {
         return this->_value;
     }
+
+	CFTypeID Pair::GetKeyTypeID(void) const
+	{
+		if (_key != NULL) return CFGetTypeID(_key);
+		else return 0;	// _kCFRuntimeNotATypeID
+	}
+
+	CFTypeID Pair::GetValueTypeID(void) const
+	{
+		if (_value != NULL) return CFGetTypeID(_value);
+		else return 0;	// _kCFRuntimeNotATypeID
+	}
             
     void Pair::SetKey( CFTypeRef key )
     {


### PR DESCRIPTION
Useful for quickly validating that the pair key or value is the correct type to use with a CF function